### PR TITLE
support extends field in tsconfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,11 +88,21 @@ async function cleanup(opts: { tmpdir: string; maxItems: number }) {
   }
 }
 
+async function load(cwd: string, filename?: string) {
+  let tsConfig = await tscfg.load(cwd, filename);
+  let extend = tsConfig?.config?.extends;
+  if (extend) {
+    let parent = await load(cwd,extend);
+    tsConfig.config = Object.assign(parent.config,tsConfig.config);
+  }
+  return tsConfig;
+}
+
 async function compile(opts: { tsconfig: string | undefined; tmpdir: string }) {
   let process_cwd = process.cwd();
   let tsConfig = null;
   try {
-    tsConfig = await tscfg.load(process_cwd, opts.tsconfig);
+    tsConfig = await load(process_cwd, opts.tsconfig);
   } catch (e) {}
 
   if (!tsConfig || !tsConfig.config) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ let mkdirpAsync = util.promisify(mkdirp);
 let copyAsync = async (src: string, dest: string, _opts?: any) => {
   await mkdirpAsync(dest);
   let copyProcess = await cp.spawnSync('bash', ['-c', `cp -r ${src}/. ${dest}`]);
-  if (copyProcess.status > 0) {
+  if (copyProcess.status! > 0) {
     console.error(copyProcess.stderr.toString());
     process.exit(1);
   }
@@ -26,7 +26,7 @@ let hashSync = (items: string[], criteria: string = '') => {
     ' '
   )} -type f ${criteria} | xargs tail -n +1 | git hash-object --stdin`;
   let hashRes = cp.spawnSync('bash', ['-c', cmd], { encoding: 'utf8' });
-  if (hashRes.status > 0) {
+  if (hashRes.status! > 0) {
     throw new Error(hashRes.stderr);
   }
   let hash = hashRes.stdout.trim();
@@ -41,7 +41,7 @@ let statAsync = util.promisify(fs.stat);
 let utimesAsync = util.promisify(fs.utimes);
 let rmdirAsync = (path: string) => {
   let rm = cp.spawnSync('bash', ['-c', `rm -r ${path}`]);
-  if (rm.status > 0) {
+  if (rm.status! > 0) {
     throw new Error(rm.stderr.toString());
   }
 };
@@ -167,7 +167,7 @@ async function compile(opts: { tsconfig: string | undefined; tmpdir: string }) {
     if (out.stdout) console.log(out.stdout);
     if (out.stderr) console.error(out.stderr);
     if (out.status != 0) {
-      process.exit(out.status);
+      process.exit(out.status!);
     } else {
       let hashOut = hashSync([outDir], "-name '*.d.ts'");
       fs.writeFileSync(path.resolve(outDirFull, HASH_FILE_NAME), hashOut);


### PR DESCRIPTION
Resolved issue https://github.com/hfour/ctsc/issues/4

## Example
cli:
```bash
ctsc -p tsconfig.build.json
```
tsconfig.json:
```json
{
  "compilerOptions": {
    "module": "commonjs",
    "moduleResolution": "node",
    "target": "es2015",
    "outDir": "dist"
  },
  "include": [
    "src/**/*.ts",
    "test/**/*.ts"
  ],
  "exclude": [
    "node_modules"
  ]
}
```
tsconfig.build.json:
```json
{
  "extends": "./tsconfig.json",
  "include": [
    "src/**/*.ts"
  ],
  "exclude": [
    "node_modules"
  ]
}
```
Before this PR, it will throw `TypeError: Cannot read property 'outDir' of undefined`